### PR TITLE
Add Setting to Preserve Host Name When Instance is Launched by a Cloud Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,12 @@ None currently.
 
     # The server's hostname. This defaults to the hostname defined in `ansible_hostname`.
     server_hostname: "{{ ansible_hostname }}"
-    
+
     # Set to `true` if you want the role to use the server's EC2 Name tag as the hostname.
     hostname_from_ec2_Name_tag: false
+
+    # Set to `false` if you would like cloudinit to replace the hostname when launching the instance
+    cloud_init_preserve_hostname: true
 
 
 Requirements

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ None currently.
     hostname_from_ec2_Name_tag: false
 
     # Set to `false` if you would like cloudinit to replace the hostname when launching the instance
-    cloud_init_preserve_hostname: true
+    hostname_cloud_init_preserve_hostname: true
 
 
 Requirements

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 server_hostname: "{{ ansible_hostname }}"
 hostname_from_ec2_Name_tag: false
-cloud_init_preserve_hostname: true
+hostname_cloud_init_preserve_hostname: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 server_hostname: "{{ ansible_hostname }}"
 hostname_from_ec2_Name_tag: false
+cloud_init_preserve_hostname: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,3 +23,9 @@
   hostname:
     name: "{{ _hostname_to_use }}"
 
+- name: Configure cloudinit option on preserving hostname
+  lineinfile:
+    dest: /etc/cloud/cloud.cfg
+    regexp: "^preserve_hostname:[ \t]+false"
+    line: "preserve_hostname: {{ cloud_init_preserve_hostname }}"
+    state: present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,5 +27,5 @@
   lineinfile:
     dest: /etc/cloud/cloud.cfg
     regexp: "^preserve_hostname:[ \t]+false"
-    line: "preserve_hostname: {{ cloud_init_preserve_hostname }}"
+    line: "preserve_hostname: {{ hostname_cloud_init_preserve_hostname }}"
     state: present


### PR DESCRIPTION

Cloud services such as AWS use cloudinit to launch instances. The default behavior for cloudinit is to set the instance hostname on first boot to a provider-specific value such as host private IP by AWS.

This PR adds a task to set [cloudinit configuration](https://cloudinit.readthedocs.io/en/latest/topics/modules.html#set-hostname) to whether preserve the hostname on launch. 
This makes it possible for an image built with a hostname set to preserve that hostname when an instance using that image is launched.