### PR TITLE
Fixes Typo in _filter_ip_address Variable Name

### DIFF
--- a/tasks/get-hostname-ec2-tag.yml
+++ b/tasks/get-hostname-ec2-tag.yml
@@ -7,7 +7,7 @@
 - block:
   - name: Register the instance's IP address
     set_fact:
-      _filterq_ip_address: "{{ ansible_ssh_host }}"
+      _filter_ip_address: "{{ ansible_ssh_host }}"
 
   - name: Get EC2 facts using host IP address
     become: no


### PR DESCRIPTION
Fixes typo in the variable _filter_ip_address variable in one of the tasks.

Signed-off-by: Jason Rogena <jason@rogena.me>