### PR TITLE
Makes Hostname Canonical in /etc/hosts File

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,8 +15,7 @@
 - name: Hosts
   lineinfile:
     dest: /etc/hosts
-    regexp: '^127\.0\.0\.1[ \t]+localhost'
-    line: '127.0.0.1 localhost {{ _hostname_to_use }}'
+    line: '127.0.0.1 {{ _hostname_to_use }}'
     state: present
 
 - name: Set hostname to {{ _hostname_to_use }}


### PR DESCRIPTION
Instead of making the hostname an alias in the /etc/hosts file, make it
a canonical name (first name after the loopback address). RabbitMQ fails
to authenticate on hosts that have the hostname set as an alias (any
record after the canonical name in a line). Error thrown is:

`Hostname mismatch: node believes its host is different`

Related to rabbitmq/discussions#53

Signed-off-by: Jason Rogena <jason@rogena.me>