### PR TITLE
Checks if cloud-init Config File Exists

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,12 +25,17 @@
 - name: Check if cloud-init is installed
   command: "{{ hostname_cloud_init_check_command }}"
   ignore_errors: true
-  register: hostname_cloud_init_status
+  register: hostname_cloud_init_install_status
+
+- name: Check if cloud-init config dir exists
+  stat:
+    path: "{{ hostname_cloudinit_config_file }}"
+  register: hostname_cloud_init_config_status
 
 - name: Configure cloudinit option on preserving hostname
   lineinfile:
-    dest: /etc/cloud/cloud.cfg
+    dest: "{{ hostname_cloudinit_config_file }}"
     regexp: "^preserve_hostname:[ \t]+false"
     line: "preserve_hostname: {{ hostname_cloud_init_preserve_hostname }}"
     state: present
-  when: hostname_cloud_init_status.rc == 0
+  when: hostname_cloud_init_install_status.rc == 0 and hostname_cloud_init_config_status.stat.exists

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,2 @@
+---
+hostname_cloudinit_config_file: /etc/cloud/cloud.cfg


### PR DESCRIPTION
Checks if the cloud-init configuration file exists before trying to add
in the preserve_hostname configuration. This is so as to support hosts
that might have the cloud-init package installed, but not configured.

Signed-off-by: Jason Rogena <jason@rogena.me>